### PR TITLE
Main: Ensure there are no duplicate calls of dhTestRun in the main method

### DIFF
--- a/AsynchronousRatchetingTree/src/main/java/com/facebook/research/asynchronousratchetingtree/Main.java
+++ b/AsynchronousRatchetingTree/src/main/java/com/facebook/research/asynchronousratchetingtree/Main.java
@@ -62,6 +62,7 @@ public class Main {
       if (n == lastNumber) {
         continue;
       }
+      lastNumber = n;
       System.gc();
       dhResults.add(dhTestRun(n, n));
     }


### PR DESCRIPTION
The value `lastNumber` was initialized but not updated in a loop, rendering the use of the variable obsolete. This patch ensures the variable is updated on each pass, to ensure the behavior when calling `dhTestRun` matches the behavior when calling `artTestRun` (line 50).